### PR TITLE
Disable CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,49 +1,50 @@
-name: Production
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-
-permissions:
-  id-token: write
-  contents: read
-
-jobs:
-  ci:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: eu-west-3
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          mask-password: 'true'
-      - name: Build, tag, and push docker image to Amazon ECR
-        env:
-          REGISTRY: 519236269948.dkr.ecr.eu-west-3.amazonaws.com
-          REPOSITORY: code-perdu
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $REGISTRY/$REPOSITORY:latest .
-          docker push $REGISTRY/$REPOSITORY:latest
-      - name: ZIP the Dockerrun file
-        run: |
-          zip -r code-perdu.zip Dockerrun.aws.json
-      - name: Send the docker run file to S3
-        run: |
-          aws s3 cp code-perdu.zip s3://elasticbeanstalk-eu-west-3-519236269948/latest.zip
-      - name: Deploy to elastic beanstalk
-        run: |
-          aws elasticbeanstalk create-application-version --application-name code-perdu --version-label ${{ github.sha }} --source-bundle S3Bucket="elasticbeanstalk-eu-west-3-519236269948",S3Key="latest.zip"
-          aws elasticbeanstalk update-environment --application-name code-perdu --environment-name code-perdu --version-label ${{ github.sha }}
+#name: Production
+#on:
+#  push:
+#    branches:
+#      - main
+#  pull_request:
+#    branches:
+#      - main
+#
+#permissions:
+#  id-token: write
+#  contents: read
+#
+#jobs:
+#  ci:
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Checkout the repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+#          aws-region: eu-west-3
+#      - name: Login to Amazon ECR
+#        id: login-ecr
+#        uses: aws-actions/amazon-ecr-login@v1
+#        with:
+#          mask-password: 'true'
+#      - name: Build, tag, and push docker image to Amazon ECR
+#        env:
+#          REGISTRY: 519236269948.dkr.ecr.eu-west-3.amazonaws.com
+#          REPOSITORY: code-perdu
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker build -t $REGISTRY/$REPOSITORY:latest .
+#          docker push $REGISTRY/$REPOSITORY:latest
+#      - name: ZIP the Dockerrun file
+#        run: |
+#          zip -r code-perdu.zip Dockerrun.aws.json
+#      - name: Send the docker run file to S3
+#        run: |
+#          aws s3 cp code-perdu.zip s3://elasticbeanstalk-eu-west-3-519236269948/latest.zip
+#      - name: Deploy to elastic beanstalk
+#        run: |
+#          aws elasticbeanstalk create-application-version --application-name code-perdu --version-label ${{ github.sha }} --source-bundle S3Bucket="elasticbeanstalk-eu-west-3-519236269948",S3Key="latest.zip"
+#          aws elasticbeanstalk update-environment --application-name code-perdu --environment-name code-perdu --version-label ${{ github.sha }}
+#


### PR DESCRIPTION
Le temps qu'on a des problèmes de droits AWS, c'est mieux de désactiver l'intégration continue.